### PR TITLE
Refactor main screen and implement statistics view

### DIFF
--- a/Zikirler/ContentView.swift
+++ b/Zikirler/ContentView.swift
@@ -9,13 +9,28 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationView {
+            VStack {
+                Text("Ana Ekran")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .padding()
+                
+                NavigationLink(destination: StatisticsView()) {
+                    Text("İstatistikleri Görüntüle")
+                        .font(.headline)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundColor(.white)
+                        .cornerRadius(10)
+                }
+                .padding(.top, 20) // Add some space above the button
+
+                Spacer() // Add spacer to push content to the top
+            }
+            .navigationTitle("Zikirler") // Set navigation bar title
+            .navigationBarTitleDisplayMode(.inline) // Optional: Use inline display mode
         }
-        .padding()
     }
 }
 

--- a/Zikirler/Models/ZikirEntry.swift
+++ b/Zikirler/Models/ZikirEntry.swift
@@ -1,0 +1,34 @@
+//
+//  ZikirEntry.swift
+//  Zikirler
+//
+//  Created by Your Name on \(Date())
+//
+
+import Foundation
+
+struct ZikirEntry: Identifiable, Codable {
+    var id: UUID = UUID() // Automatically generated default value
+    var name: String        // e.g., "Subhanallah", "Alhamdulillah"
+    var count: Int          // The number of times this dhikr was recited
+    var date: Date          // The date and time when this dhikr entry was recorded
+}
+
+// Example Usage (Optional - can be removed or commented out)
+/*
+let exampleEntry = ZikirEntry(name: "Sübhanallah", count: 100, date: Date())
+let exampleEntry2 = ZikirEntry(id: UUID(), name: "Elhamdülillah", count: 50, date: Date().addingTimeInterval(-3600)) // Example with explicit ID and different time
+
+func printEntry(entry: ZikirEntry) {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateStyle = .medium
+    dateFormatter.timeStyle = .short
+    print("ID: \(entry.id)")
+    print("Zikir Adı: \(entry.name)")
+    print("Sayısı: \(entry.count)")
+    print("Tarih: \(dateFormatter.string(from: entry.date))")
+}
+
+// printEntry(entry: exampleEntry)
+// printEntry(entry: exampleEntry2)
+*/

--- a/Zikirler/Persistence/ZikirDataManager.swift
+++ b/Zikirler/Persistence/ZikirDataManager.swift
@@ -1,0 +1,109 @@
+//
+//  ZikirDataManager.swift
+//  Zikirler
+//
+//  Created by Your Name on \(Date())
+//
+
+import Foundation
+
+class ZikirDataManager {
+
+    private static let userDefaultsKey = "zikirEntries"
+
+    // MARK: - Saving Data
+    
+    /// Saves an array of ZikirEntry objects to UserDefaults.
+    /// - Parameter entries: The array of ZikirEntry objects to save.
+    static func saveZikirEntries(_ entries: [ZikirEntry]) {
+        do {
+            let encoder = JSONEncoder()
+            let encodedData = try encoder.encode(entries)
+            UserDefaults.standard.set(encodedData, forKey: userDefaultsKey)
+            print("Zikir entries saved successfully.")
+        } catch {
+            print("Error encoding ZikirEntry array: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Loading Data
+
+    /// Loads an array of ZikirEntry objects from UserDefaults.
+    /// - Returns: An array of ZikirEntry objects. Returns an empty array if no data is found or if decoding fails.
+    static func loadZikirEntries() -> [ZikirEntry] {
+        guard let savedData = UserDefaults.standard.data(forKey: userDefaultsKey) else {
+            print("No saved zikir entries found.")
+            return []
+        }
+        
+        do {
+            let decoder = JSONDecoder()
+            let loadedEntries = try decoder.decode([ZikirEntry].self, from: savedData)
+            print("Zikir entries loaded successfully.")
+            return loadedEntries
+        } catch {
+            print("Error decoding ZikirEntry array: \(error.localizedDescription)")
+            return [] // Return empty array in case of an error
+        }
+    }
+    
+    // MARK: - Convenience Methods (Optional)
+
+    /// Adds a new ZikirEntry and saves the updated list.
+    static func addZikirEntry(name: String, count: Int, date: Date = Date()) {
+        var currentEntries = loadZikirEntries()
+        let newEntry = ZikirEntry(name: name, count: count, date: date)
+        currentEntries.append(newEntry)
+        saveZikirEntries(currentEntries)
+        print("New zikir entry '\(name)' added and saved.")
+    }
+
+    /// Clears all ZikirEntry data from UserDefaults.
+    static func clearAllZikirEntries() {
+        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+        print("All zikir entries cleared from UserDefaults.")
+    }
+}
+
+// Example Usage (Optional - can be commented out or removed)
+/*
+func demonstrateZikirDataManager() {
+    // Clear any existing data for a clean test
+    ZikirDataManager.clearAllZikirEntries()
+
+    // Load initial (should be empty)
+    var entries = ZikirDataManager.loadZikirEntries()
+    print("Loaded entries count initially: \(entries.count)")
+
+    // Add a few entries
+    ZikirDataManager.addZikirEntry(name: "Sübhanallah", count: 100)
+    ZikirDataManager.addZikirEntry(name: "Elhamdülillah", count: 200, date: Date().addingTimeInterval(-86400)) // Yesterday
+    ZikirDataManager.addZikirEntry(name: "Allahu Ekber", count: 150)
+
+    // Load again
+    entries = ZikirDataManager.loadZikirEntries()
+    print("Loaded entries count after adding: \(entries.count)")
+
+    for entry in entries {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm"
+        print(" - \(entry.name): \(entry.count) (ID: \(entry.id), Date: \(dateFormatter.string(from: entry.date)))")
+    }
+
+    // Example of saving a modified list directly (e.g., if you modify counts or remove items)
+    if var firstEntry = entries.first {
+        firstEntry.count += 50
+        entries[0] = firstEntry
+        ZikirDataManager.saveZikirEntries(entries)
+        print("Modified first entry and re-saved.")
+    }
+    
+    let updatedEntries = ZikirDataManager.loadZikirEntries()
+    if let firstEntry = updatedEntries.first {
+         print("Updated count for first entry: \(firstEntry.count)")
+    }
+}
+
+// Call the demonstration function
+// demonstrateZikirDataManager()
+*/

--- a/Zikirler/Views/Screens/StatisticsView.swift
+++ b/Zikirler/Views/Screens/StatisticsView.swift
@@ -1,0 +1,166 @@
+//
+//  StatisticsView.swift
+//  Zikirler
+//
+//  Created by Your Name on \(Date()) // Note: This date won't update dynamically after file creation.
+//
+
+import SwiftUI
+
+struct StatisticsView: View {
+    @State private var allEntries: [ZikirEntry] = []
+
+    var body: some View {
+        VStack {
+            Text("İstatistikler")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .padding(.bottom, 20)
+
+            // Total Entries for context
+            Text("Toplam Kayıtlı Zikir: \(allEntries.count)")
+                .font(.headline)
+                .padding(.bottom, 10)
+
+            // Weekly Statistics Section
+            VStack(alignment: .leading) {
+                Text("Haftalık İstatistikler")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                let weeklyEntries = filterEntries(for: .week)
+                Text("Bu Haftaki Zikir Sayısı: \(weeklyEntries.count)")
+                    .padding(.top, 5)
+                if let firstWeekly = weeklyEntries.first {
+                    Text("Örnek Haftalık Zikir: \(firstWeekly.name) (\(firstWeekly.count))")
+                        .padding(.top, 5)
+                } else {
+                    Text("Bu hafta için kayıtlı zikir yok.")
+                        .padding(.top, 5)
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            .padding(.bottom, 20)
+
+            // Monthly Statistics Section
+            VStack(alignment: .leading) {
+                Text("Aylık İstatistikler")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                let monthlyEntries = filterEntries(for: .month)
+                Text("Bu Aylık Zikir Sayısı: \(monthlyEntries.count)")
+                    .padding(.top, 5)
+                if monthlyEntries.isEmpty {
+                    Text("Bu ay için kayıtlı zikir yok.")
+                        .padding(.top, 5)
+                } else {
+                    Text("Bu ay kaydedilen zikirlerden bazıları:")
+                        .padding(.top, 5)
+                    ForEach(monthlyEntries.prefix(2), id: \.id) { entry in
+                        Text("- \(entry.name): \(entry.count)")
+                    }
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            .padding(.bottom, 20)
+
+            // Yearly Statistics Section
+            VStack(alignment: .leading) {
+                Text("Yıllık İstatistikler")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                let yearlyEntries = filterEntries(for: .year)
+                Text("Bu Yıllık Zikir Sayısı: \(yearlyEntries.count)")
+                    .padding(.top, 5)
+                if !yearlyEntries.isEmpty {
+                    Text("Yıl boyunca kaydedilen toplam zikir: \(yearlyEntries.reduce(0) { $0 + $1.count })")
+                        .padding(.top, 5)
+                } else {
+                    Text("Bu yıl için kayıtlı zikir yok.")
+                        .padding(.top, 5)
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+
+            Spacer() // Pushes content to the top
+        }
+        .padding()
+        .navigationTitle("İstatistikler")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            loadData()
+        }
+    }
+
+    func loadData() {
+        let loaded = ZikirDataManager.loadZikirEntries()
+        if loaded.isEmpty {
+            print("No existing data found. Creating sample data...")
+            // Create diverse sample data
+            var sampleEntries: [ZikirEntry] = []
+            let calendar = Calendar.current
+
+            // Today
+            sampleEntries.append(ZikirEntry(name: "Sübhanallah", count: 100, date: Date()))
+            sampleEntries.append(ZikirEntry(name: "Elhamdülillah", count: 50, date: Date()))
+            
+            // Last Week
+            if let lastWeekDate = calendar.date(byAdding: .weekOfYear, value: -1, to: Date()) {
+                sampleEntries.append(ZikirEntry(name: "Allahu Ekber", count: 75, date: lastWeekDate))
+                sampleEntries.append(ZikirEntry(name: "Lâ ilâhe illallah", count: 120, date: calendar.date(byAdding: .day, value: -2, to: lastWeekDate)!))
+            }
+
+            // Last Month
+            if let lastMonthDate = calendar.date(byAdding: .month, value: -1, to: Date()) {
+                sampleEntries.append(ZikirEntry(name: "Estağfirullah", count: 200, date: lastMonthDate))
+                 sampleEntries.append(ZikirEntry(name: "Salli Ala Muhammed", count: 60, date: calendar.date(byAdding: .day, value: -5, to: lastMonthDate)!))
+            }
+            
+            // Last Year
+            if let lastYearDate = calendar.date(byAdding: .year, value: -1, to: Date()) {
+                sampleEntries.append(ZikirEntry(name: "Ya Latif", count: 300, date: lastYearDate))
+                 sampleEntries.append(ZikirEntry(name: "Ya Hafız", count: 90, date: calendar.date(byAdding: .month, value: -2, to: lastYearDate)!))
+            }
+            
+            self.allEntries = sampleEntries
+            ZikirDataManager.saveZikirEntries(self.allEntries)
+            print("Sample data created and saved. Total: \(self.allEntries.count)")
+        } else {
+            self.allEntries = loaded
+            print("Existing data loaded. Total: \(self.allEntries.count)")
+        }
+    }
+
+    enum TimePeriod {
+        case week, month, year
+    }
+
+    func filterEntries(for period: TimePeriod) -> [ZikirEntry] {
+        let calendar = Calendar.current
+        let now = Date()
+        
+        return allEntries.filter { entry in
+            switch period {
+            case .week:
+                return calendar.isDate(entry.date, equalTo: now, toGranularity: .weekOfYear) &&
+                       calendar.isDate(entry.date, equalTo: now, toGranularity: .yearForWeekOfYear)
+            case .month:
+                return calendar.isDate(entry.date, equalTo: now, toGranularity: .month) &&
+                       calendar.isDate(entry.date, equalTo: now, toGranularity: .year)
+            case .year:
+                return calendar.isDate(entry.date, equalTo: now, toGranularity: .year)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationView {
+        StatisticsView()
+    }
+}

--- a/ZikirlerTests/ZikirlerTests.swift
+++ b/ZikirlerTests/ZikirlerTests.swift
@@ -7,11 +7,131 @@
 
 import Testing
 @testable import Zikirler
+import Foundation // Required for Date, UUID, JSONEncoder, JSONDecoder
 
 struct ZikirlerTests {
 
     @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        // This is a default test, can be removed or kept.
+        #expect(true == true)
     }
 
+    @Test func testZikirEntryInitializationAndCodable() throws {
+        let testID = UUID()
+        let testDate = Date()
+        let testName = "Test Zikir"
+        let testCount = 100
+
+        // 1. Test Initialization
+        let entry = ZikirEntry(id: testID, name: testName, count: testCount, date: testDate)
+        #expect(entry.id == testID)
+        #expect(entry.name == testName)
+        #expect(entry.count == testCount)
+        #expect(entry.date == testDate)
+
+        // 2. Test Codable Conformance
+        // Encode
+        let encoder = JSONEncoder()
+        let data = try #require(encoder.encode(entry))
+
+        // Decode
+        let decoder = JSONDecoder()
+        let decodedEntry = try #require(decoder.decode(ZikirEntry.self, from: data))
+
+        // Assert decoded object's properties
+        #expect(decodedEntry.id == entry.id)
+        #expect(decodedEntry.name == entry.name)
+        #expect(decodedEntry.count == entry.count)
+        // Date comparison needs to be done carefully due to precision.
+        // Encoding and decoding can sometimes result in very minor differences.
+        // For practical purposes, comparing timeIntervalSince1970 is robust.
+        #expect(abs(decodedEntry.date.timeIntervalSince1970 - entry.date.timeIntervalSince1970) < 0.001)
+    }
+    
+    @Test func testZikirEntryDefaultID() throws {
+        let testName = "Default ID Zikir"
+        let testCount = 50
+        let testDate = Date()
+        
+        let entry = ZikirEntry(name: testName, count: testCount, date: testDate)
+        // Check that an ID was generated
+        #expect(entry.id != UUID.null) // UUID.null is a common way to represent an empty/nil UUID
+    }
+
+
+    @Test func testZikirDataManagerSaveLoadClear() throws {
+        // 0. Start with a clean slate
+        ZikirDataManager.clearAllZikirEntries()
+        var loadedEntries = ZikirDataManager.loadZikirEntries()
+        #expect(loadedEntries.isEmpty == true, "Entries should be empty after clearing.")
+
+        // 1. Create sample data
+        let date1 = Date().addingTimeInterval(-1000)
+        let date2 = Date()
+        let entry1 = ZikirEntry(name: "Sübhanallah", count: 100, date: date1)
+        let entry2 = ZikirEntry(name: "Elhamdülillah", count: 200, date: date2)
+        let sampleEntries = [entry1, entry2]
+
+        // 2. Save entries
+        ZikirDataManager.saveZikirEntries(sampleEntries)
+
+        // 3. Load entries
+        loadedEntries = ZikirDataManager.loadZikirEntries()
+        #expect(loadedEntries.count == 2, "Should load 2 entries.")
+
+        // 4. Assert content (order might not be guaranteed by UserDefaults)
+        let loadedEntry1 = loadedEntries.first { $0.name == "Sübhanallah" }
+        let loadedEntry2 = loadedEntries.first { $0.name == "Elhamdülillah" }
+
+        #expect(loadedEntry1 != nil)
+        #expect(loadedEntry1?.count == 100)
+        #expect(abs(loadedEntry1!.date.timeIntervalSince1970 - date1.timeIntervalSince1970) < 0.001)
+        
+        #expect(loadedEntry2 != nil)
+        #expect(loadedEntry2?.count == 200)
+        #expect(abs(loadedEntry2!.date.timeIntervalSince1970 - date2.timeIntervalSince1970) < 0.001)
+
+        // 5. Test clearing data
+        ZikirDataManager.clearAllZikirEntries()
+        let finalEntries = ZikirDataManager.loadZikirEntries()
+        #expect(finalEntries.isEmpty == true, "Entries should be empty after final clear.")
+    }
+    
+    @Test func testZikirDataManagerLoadEmpty() throws {
+        ZikirDataManager.clearAllZikirEntries() // Ensure no data
+        let entries = ZikirDataManager.loadZikirEntries()
+        #expect(entries.isEmpty == true)
+    }
+    
+    @Test func testZikirDataManagerAddEntry() throws {
+        ZikirDataManager.clearAllZikirEntries()
+        
+        let initialCount = ZikirDataManager.loadZikirEntries().count
+        #expect(initialCount == 0)
+        
+        let testName = "Test Add Zikir"
+        let testCount = 33
+        let testDate = Date()
+        
+        ZikirDataManager.addZikirEntry(name: testName, count: testCount, date: testDate)
+        
+        let entriesAfterAdd = ZikirDataManager.loadZikirEntries()
+        #expect(entriesAfterAdd.count == initialCount + 1)
+        
+        let addedEntry = entriesAfterAdd.first
+        #expect(addedEntry != nil)
+        #expect(addedEntry?.name == testName)
+        #expect(addedEntry?.count == testCount)
+        #expect(abs(addedEntry!.date.timeIntervalSince1970 - testDate.timeIntervalSince1970) < 0.001)
+        
+        // Clean up
+        ZikirDataManager.clearAllZikirEntries()
+    }
+}
+
+// Helper extension for UUID.null if not available (Swift Testing might not need this)
+extension UUID {
+    static var null: UUID {
+        return UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+    }
 }

--- a/ZikirlerUITests/ZikirlerUITests.swift
+++ b/ZikirlerUITests/ZikirlerUITests.swift
@@ -38,4 +38,34 @@ final class ZikirlerUITests: XCTestCase {
             XCUIApplication().launch()
         }
     }
+
+    @MainActor
+    func testNavigateToStatisticsView() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // 1. Verify the "İstatistikleri Görüntüle" button/link exists and tap it.
+        // In SwiftUI, NavigationLink containing Text will often make the Text its accessibility label.
+        let statisticsButton = app.buttons["İstatistikleri Görüntüle"]
+        
+        // It's good to wait for the element to exist, especially in UI tests.
+        XCTAssertTrue(statisticsButton.waitForExistence(timeout: 5), "The 'İstatistikleri Görüntüle' button should exist.")
+        statisticsButton.tap()
+
+        // 2. Verify that the navigation occurs and the StatisticsView is displayed.
+        // We check for the navigation bar title of StatisticsView.
+        // Note: `navigationBars` elements are identified by their title.
+        let statisticsNavBar = app.navigationBars["İstatistikler"]
+        XCTAssertTrue(statisticsNavBar.waitForExistence(timeout: 5), "The 'İstatistikler' navigation bar should be visible after tapping the button.")
+        
+        // 3. Optionally, verify some content on the StatisticsView
+        // For example, checking for the main title text if it's made accessible.
+        // Let's assume the "İstatistikler" title within the VStack is also identifiable.
+        // If it's a staticText, we can look for it.
+        // This depends on how `Text("İstatistikler").font(.largeTitle)` is rendered for accessibility.
+        // Often, direct Text elements used as titles are also queryable.
+        let statisticsViewTitle = app.staticTexts["İstatistikler"]
+        XCTAssertTrue(statisticsViewTitle.exists, "The 'İstatistikler' title text should be visible on the StatisticsView.")
+    }
 }


### PR DESCRIPTION
- I implemented ContentView as the main screen with a clean layout and NavigationView.
- I created StatisticsView as a new screen to display dhikr statistics.
- I added navigation from ContentView to StatisticsView.
- I introduced the ZikirEntry data model (Identifiable, Codable) with id, name, count, and date.
- I implemented ZikirDataManager for basic persistence of ZikirEntry objects using UserDefaults (save, load, add, clear).
- StatisticsView now loads and displays sample ZikirEntry data, with placeholder UI for weekly, monthly, and yearly stats.
- I added unit tests for the ZikirEntry model, Codable conformance, and ZikirDataManager operations.
- I added UI tests to verify navigation to StatisticsView and the presence of key screen elements.

This addresses the issue by removing statistics from the (previously non-existent) main screen, creating a dedicated statistics screen, and setting up the foundational data model and persistence for future statistical calculations.